### PR TITLE
New Melpa Recipe for gitignore-mode

### DIFF
--- a/helm-gitignore.el
+++ b/helm-gitignore.el
@@ -4,7 +4,7 @@
 ;; Version: 0.2.0
 ;; Keywords: helm gitignore gitignore.io
 ;; Homepage: https://github.com/jupl/helm-gitignore
-;; Package-Requires: ((gitignore-mode "1.1.0") (helm "1.7.0") (request "0.1.0") (cl-lib "0.5"))
+;; Package-Requires: ((git-modes "1.4.0") (helm "1.7.0") (request "0.1.0") (cl-lib "0.5"))
 
 ;;; Commentary:
 ;;


### PR DESCRIPTION
Hey!

Just recently,
https://github.com/melpa/melpa/commit/cc3a0ce6c8a4a67b8a8d4b8b2c090694535e6848,
was merged and

gitattributes-mode
gitconfig-mode
gitignore-mode

have been subsumed into one singular git-modes.

Have a good one,